### PR TITLE
Patch for space between y-axis and y-axis label when hasCustomProperty is true on v1.0.0.

### DIFF
--- a/src/main/js/helpers/axis.js
+++ b/src/main/js/helpers/axis.js
@@ -670,9 +670,8 @@ const isXAxisOrientationTop = (xAxisOrientation) =>
  */
 const calculateAxesSize = (config) => {
     config.axisSizes = {};
-    config.axisSizes.y = config.padding.hasCustomPadding
-        ? getYAxisWidth(constants.Y_AXIS, config)
-        : getYAxisWidth(constants.Y_AXIS, config) + config.padding.left;
+    config.axisSizes.y =
+        getYAxisWidth(constants.Y_AXIS, config) + config.padding.left;
     config.axisSizes.y2 = getY2AxisWidth(config);
     config.axisSizes.x = getXAxisHeight(config);
 };

--- a/src/test/unit/controls/Graph/Graph-spec.js
+++ b/src/test/unit/controls/Graph/Graph-spec.js
@@ -1190,7 +1190,7 @@ describe("Graph", () => {
                     `.${styles.contentContainer}`
                 );
                 expect(toNumber(contentContainer.attr("x"), 10)).toBeCloserTo(
-                    0
+                    -16
                 );
                 expect(toNumber(contentContainer.attr("y"), 10)).toBeCloserTo(
                     graphConfig.padding.bottom
@@ -1201,7 +1201,7 @@ describe("Graph", () => {
                             graph.config.axisLabelWidths.y,
                         10
                     )
-                ).toBeCloserTo(0);
+                ).toBeCloserTo(-16);
                 expect(getYAxisHeight(graph.config)).toBeCloserTo(267);
             });
             it("Resizes correctly after rendering", (done) => {
@@ -1248,7 +1248,7 @@ describe("Graph", () => {
                     `.${styles.contentContainer}`
                 );
                 expect(toNumber(contentContainer.attr("x"), 10)).toBeCloserTo(
-                    0
+                    -16
                 );
                 expect(toNumber(contentContainer.attr("y"), 10)).toBeCloserTo(
                     toNumber(
@@ -1274,7 +1274,7 @@ describe("Graph", () => {
                     `.${styles.contentContainer}`
                 );
                 expect(toNumber(contentContainer.attr("x"), 10)).toBeCloserTo(
-                    0
+                    -16
                 );
                 expect(toNumber(contentContainer.attr("y"), 10)).toBeCloserTo(
                     graphConfig.padding.top
@@ -2568,7 +2568,7 @@ describe("Graph", () => {
                 );
                 expect(
                     toNumber(contentContainer.getAttribute("x"), 10)
-                ).toBeCloserTo(0);
+                ).toBeCloserTo(-16);
                 expect(
                     toNumber(contentContainer.getAttribute("y"), 10)
                 ).toBeCloserTo(0);
@@ -2749,7 +2749,7 @@ describe("Graph", () => {
                     `.${styles.contentContainer}`
                 );
                 expect(toNumber(contentContainer.attr("x"), 10)).toBeCloserTo(
-                    0
+                    -16
                 );
                 expect(toNumber(contentContainer.attr("y"), 10)).toBeCloserTo(
                     0
@@ -2760,7 +2760,7 @@ describe("Graph", () => {
                             graph.config.axisLabelWidths.y,
                         10
                     )
-                ).toBeCloserTo(0);
+                ).toBeCloserTo(-16);
                 expect(getYAxisHeight(graph.config)).toBeCloserTo(267);
             });
             it("Renders correctly on another resize", (done) => {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

**What is the purpose of this pull request? (Check any that's applicable)**

-   [ ] Feature
-   [ ] Bug fix
-   [ ] Dependency updates
-   [ ] Documentation updates
-   [ ] Build related changes
-   [ ] Changes an existing functionality
-   [x] Other, please explain: Providing patch for issue #22 on v1.0.0

**Does this introduce a breaking change?**

-   [ ] Yes
-   [x] No

