### PR TITLE
Fix: Console errors in all graphs after clicking panning button

### DIFF
--- a/src/main/js/controls/Gantt/Gantt.js
+++ b/src/main/js/controls/Gantt/Gantt.js
@@ -42,6 +42,8 @@ import { translateGraph, translateLabelText } from "./helpers/translateHelpers";
  */
 
 const BASE_CANVAS_WIDTH_PADDING = constants.BASE_CANVAS_WIDTH_PADDING;
+
+const LIVE_GRAPHS = [];
 /**
  * Sets the canvas width
  *
@@ -191,6 +193,7 @@ class Gantt extends Construct {
         processInput(input, this.config);
         beforeInit(this);
         init(this);
+        LIVE_GRAPHS.push(this);
         const containerSVG = d3
             .select(this.config.bindTo)
             .append("div")
@@ -321,9 +324,15 @@ class Gantt extends Construct {
      * @returns {Gantt} - Gantt instance
      */
     destroy() {
-        detachEventHandlers(this);
-        d3RemoveElement(this.graphContainer, `.${styles.canvas}`);
-        d3RemoveElement(this.graphContainer, `.${styles.container}`);
+        for (let i = LIVE_GRAPHS.length - 1; i >= 0; i--) {
+            detachEventHandlers(LIVE_GRAPHS[i]);
+            d3RemoveElement(LIVE_GRAPHS[i].graphContainer, `.${styles.canvas}`);
+            d3RemoveElement(
+                LIVE_GRAPHS[i].graphContainer,
+                `.${styles.container}`
+            );
+            LIVE_GRAPHS.pop();
+        }
         initConfig(this);
         return this;
     }

--- a/src/main/js/controls/Graph/Graph.js
+++ b/src/main/js/controls/Graph/Graph.js
@@ -41,6 +41,8 @@ import {
  */
 
 const BASE_CANVAS_WIDTH_PADDING = constants.BASE_CANVAS_WIDTH_PADDING;
+
+const LIVE_GRAPHS = [];
 /**
  * Sets the canvas width
  *
@@ -222,6 +224,7 @@ class Graph extends Construct {
         processInput(input, this.config, this.config.axis.x.type);
         beforeInit(this);
         init(this);
+        LIVE_GRAPHS.push(this);
         const containerSVG = d3
             .select(this.config.bindTo)
             .append("div")
@@ -363,9 +366,15 @@ class Graph extends Construct {
      * @returns {Graph} - Graph instance
      */
     destroy() {
-        detachEventHandlers(this);
-        d3RemoveElement(this.graphContainer, `.${styles.canvas}`);
-        d3RemoveElement(this.graphContainer, `.${styles.container}`);
+        for (let i = LIVE_GRAPHS.length - 1; i >= 0; i--) {
+            detachEventHandlers(LIVE_GRAPHS[i]);
+            d3RemoveElement(LIVE_GRAPHS[i].graphContainer, `.${styles.canvas}`);
+            d3RemoveElement(
+                LIVE_GRAPHS[i].graphContainer,
+                `.${styles.container}`
+            );
+            LIVE_GRAPHS.pop();
+        }
         initConfig(this);
         return this;
     }

--- a/src/main/js/controls/Timeline/Timeline.js
+++ b/src/main/js/controls/Timeline/Timeline.js
@@ -28,6 +28,8 @@ import TimelineContent from "./TimelineContent";
  * @typedef {object} TimelineConfig
  */
 const BASE_CANVAS_WIDTH_PADDING = constants.BASE_CANVAS_WIDTH_PADDING;
+
+const LIVE_GRAPHS = [];
 /**
  * Sets the canvas width
  *
@@ -177,6 +179,7 @@ class Timeline extends Construct {
         processInput(input, this.config);
         beforeInit(this);
         init(this);
+        LIVE_GRAPHS.push(this);
         const containerSVG = d3
             .select(this.config.bindTo)
             .append("div")
@@ -266,9 +269,15 @@ class Timeline extends Construct {
      * @returns {Timeline} - Timeline instance
      */
     destroy() {
-        detachEventHandlers(this);
-        d3RemoveElement(this.graphContainer, `.${styles.canvas}`);
-        d3RemoveElement(this.graphContainer, `.${styles.container}`);
+        for (let i = LIVE_GRAPHS.length - 1; i >= 0; i--) {
+            detachEventHandlers(LIVE_GRAPHS[i]);
+            d3RemoveElement(LIVE_GRAPHS[i].graphContainer, `.${styles.canvas}`);
+            d3RemoveElement(
+                LIVE_GRAPHS[i].graphContainer,
+                `.${styles.container}`
+            );
+            LIVE_GRAPHS.pop();
+        }
         initConfig(this);
         return this;
     }


### PR DESCRIPTION
Closes #93. 

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

**What is the purpose of this pull request? (Check any that's applicable)**

-   [ ] Feature
-   [X] Bug fix
-   [ ] Dependency updates
-   [ ] Documentation updates
-   [ ] Build related changes
-   [ ] Changes an existing functionality
-   [ ] Other, please explain:

**Does this introduce a breaking change?**

-   [ ] Yes
-   [X] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

**What changes did you make? (Give an overview)**
I have added a global variable `LIVE_GRAPHS` in all constructs which would keep a count of all live graphs. And whenever a graph is destroyed, it checks for all the live graphs on the page and destroys them. They could be regenerated by calling the carbon API again after calling the destroy function.