### PR TITLE
Fix: Fixes Graph padding issue when show label is set (fixes #278)

### DIFF
--- a/src/main/js/controls/Graph/Graph.js
+++ b/src/main/js/controls/Graph/Graph.js
@@ -72,7 +72,7 @@ const setCanvasWidth = (container, config) => {
  * @returns {undefined} - returns nothing
  */
 const setCanvasHeight = (config) => {
-    // Increase canvas height only when either the x-axis label is specified
+    // Increase the canvas height only when either the x-axis label is specified
     // and showLabel is set to true or x-axis show is set to true
     if ((config.showLabel && !!config.axis.x.label) || config.axis.x.show) {
         config.canvasHeight =

--- a/src/main/js/controls/Graph/Graph.js
+++ b/src/main/js/controls/Graph/Graph.js
@@ -72,7 +72,9 @@ const setCanvasWidth = (container, config) => {
  * @returns {undefined} - returns nothing
  */
 const setCanvasHeight = (config) => {
-    if (config.showLabel || config.axis.x.show) {
+    // Increase canvas height only when either the x-axis label is specified
+    // and showLabel is set to true or x-axis show is set to true
+    if ((config.showLabel && !!config.axis.x.label) || config.axis.x.show) {
         config.canvasHeight =
             getYAxisHeight(config) +
             (config.padding.bottom +

--- a/src/test/unit/controls/Graph/GraphResize-spec.js
+++ b/src/test/unit/controls/Graph/GraphResize-spec.js
@@ -16,7 +16,8 @@ import {
     fetchElementByClass,
     getAxes,
     getData,
-    valuesDefault
+    valuesDefault,
+    axisDefaultWithoutXAxisLabel
 } from "./helpers";
 
 describe("Graph - Resize", () => {
@@ -476,10 +477,27 @@ describe("Graph - Resize", () => {
             );
         });
     });
-    describe("When x-axis show is set to true and showLabel is set to false", () => {
+    describe("When x-axis show is set to true and showLabel is set to false and x-axis label is specified", () => {
         it("Sets canvas height correctly", () => {
             graph.destroy();
-            const axisObj = utils.deepClone(axisDefault);
+            const axisObj = utils.deepClone(axisDefaultWithoutXAxisLabel);
+            axisObj.x.show = true;
+            axisObj.x.label = "Data";
+            graph = new Graph(
+                Object.assign(
+                    {
+                        showLabel: false
+                    },
+                    getAxes(axisObj)
+                )
+            );
+            expect(graph.config.canvasHeight).toBe(270);
+        });
+    });
+    describe("When x-axis show is set to true and showLabel is set to false and x-axis label is not specified", () => {
+        it("Sets canvas height correctly", () => {
+            graph.destroy();
+            const axisObj = utils.deepClone(axisDefaultWithoutXAxisLabel);
             axisObj.x.show = true;
             graph = new Graph(
                 Object.assign(
@@ -492,10 +510,27 @@ describe("Graph - Resize", () => {
             expect(graph.config.canvasHeight).toBe(270);
         });
     });
-    describe("When x-axis show is set to false and showLabel is set to true", () => {
+    describe("When x-axis show is set to false and showLabel is set to true and x-axis label is specified", () => {
         it("Sets canvas height correctly", () => {
             graph.destroy();
-            const axisObj = utils.deepClone(axisDefault);
+            const axisObj = utils.deepClone(axisDefaultWithoutXAxisLabel);
+            axisObj.x.show = false;
+            axisObj.x.label = "Data";
+            graph = new Graph(
+                Object.assign(
+                    {
+                        showLabel: true
+                    },
+                    getAxes(axisObj)
+                )
+            );
+            expect(graph.config.canvasHeight).toBeCloserTo(306);
+        });
+    });
+    describe("When x-axis show is set to false and showLabel is set to true and x-axis label is not specified", () => {
+        it("Reduces the extra pixels added to canvas height", () => {
+            graph.destroy();
+            const axisObj = utils.deepClone(axisDefaultWithoutXAxisLabel);
             axisObj.x.show = false;
             graph = new Graph(
                 Object.assign(
@@ -505,14 +540,15 @@ describe("Graph - Resize", () => {
                     getAxes(axisObj)
                 )
             );
-            expect(graph.config.canvasHeight).toBeCloserTo(306);
+            expect(graph.config.canvasHeight).toBeCloserTo(250);
         });
     });
-    describe("When  both x-axis show and showLabel properties are set to true", () => {
+    describe("When both x-axis show and showLabel properties are set to true and x-axis label is specified", () => {
         it("Sets canvas height correctly", () => {
             graph.destroy();
-            const axisObj = utils.deepClone(axisDefault);
+            const axisObj = utils.deepClone(axisDefaultWithoutXAxisLabel);
             axisObj.x.show = true;
+            axisObj.x.label = "Data";
             graph = new Graph(
                 Object.assign(
                     {
@@ -524,10 +560,43 @@ describe("Graph - Resize", () => {
             expect(graph.config.canvasHeight).toBeCloserTo(306);
         });
     });
-    describe("When  both x-axis show and showLabel properties are set to false", () => {
+    describe("When both x-axis show and showLabel properties are set to true and x-axis label is not specified", () => {
+        it("Sets canvas height correctly", () => {
+            graph.destroy();
+            const axisObj = utils.deepClone(axisDefaultWithoutXAxisLabel);
+            axisObj.x.show = true;
+            graph = new Graph(
+                Object.assign(
+                    {
+                        showLabel: true
+                    },
+                    getAxes(axisObj)
+                )
+            );
+            expect(graph.config.canvasHeight).toBeCloserTo(270);
+        });
+    });
+    describe("When both x-axis show and showLabel properties are set to false and x-axis label is specified", () => {
         it("Reduces the extra pixels added to canvas height", () => {
             graph.destroy();
-            const axisObj = utils.deepClone(axisDefault);
+            const axisObj = utils.deepClone(axisDefaultWithoutXAxisLabel);
+            axisObj.x.show = false;
+            axisObj.x.label = "Data";
+            graph = new Graph(
+                Object.assign(
+                    {
+                        showLabel: false
+                    },
+                    getAxes(axisObj)
+                )
+            );
+            expect(graph.config.canvasHeight).toBe(250);
+        });
+    });
+    describe("When both x-axis show and showLabel properties are set to false and x-axis label is not specified", () => {
+        it("Reduces the extra pixels added to canvas height", () => {
+            graph.destroy();
+            const axisObj = utils.deepClone(axisDefaultWithoutXAxisLabel);
             axisObj.x.show = false;
             graph = new Graph(
                 Object.assign(

--- a/src/test/unit/controls/Graph/helpers.js
+++ b/src/test/unit/controls/Graph/helpers.js
@@ -156,6 +156,17 @@ export const axisDefaultWithoutPanning = {
         enabled: false
     }
 };
+export const axisDefaultWithoutXAxisLabel = {
+    x: {
+        lowerLimit: 0,
+        upperLimit: 100
+    },
+    y: {
+        label: "Some Y Label",
+        lowerLimit: 0,
+        upperLimit: 20
+    }
+};
 /**
  * Returns the DOM element queried by Class
  *


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

**What is the purpose of this pull request? (Check any that's applicable)**

-   [ ] Feature
-   [x] Bug fix
-   [ ] Dependency updates
-   [ ] Documentation updates
-   [ ] Build related changes
-   [ ] Changes an existing functionality
-   [ ] Other, please explain:

**Does this introduce a breaking change?**

-   [ ] Yes
-   [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

**What changes did you make? (Give an overview)**
In the condition of checking showLabel and x-axis while deciding on the height of canvas, i have included one more check to see if x-axis label is specified. This makes sure that the canvas height gets increased only if either the x-axis label is specified and showLabel is set to true or if x-axis show is set to true.

**Add any screenshots**
Before the changes: (When showLabel is set to true and x-axis label is not specified, canvas height gets increased which affects the padding between canvases when multiple canvases are used)

![image](https://user-images.githubusercontent.com/60426528/88815926-7e94a280-d1d9-11ea-887a-5ca172e65888.png)


After the changes: (When showLabel is set to true and x-axis label is not specified, canvas height doesn't get increased which resolves the padding issue between canvases when multiple canvases are used)

![image](https://user-images.githubusercontent.com/60426528/88815893-776d9480-d1d9-11ea-8083-7aa274f66a39.png)

