### PR TITLE
Fix: Resize Handler Console Error Fix (fixes #316)

### DIFF
--- a/src/main/js/controls/Graph/Graph.js
+++ b/src/main/js/controls/Graph/Graph.js
@@ -320,10 +320,13 @@ class Graph extends Construct {
      *  @returns {Graph} - Graph instance
      */
     resize() {
-        setCanvasWidth(this.graphContainer, this.config);
-        scaleGraph(this.scale, this.config);
-        translateGraph(this);
-        this.content.forEach((control) => control.resize(this));
+        // Check if graphContainer is present and then resize the graph
+        if (this.graphContainer) {
+            setCanvasWidth(this.graphContainer, this.config);
+            scaleGraph(this.scale, this.config);
+            translateGraph(this);
+            this.content.forEach((control) => control.resize(this));
+        }
         return this;
     }
 

--- a/src/test/unit/controls/Graph/GraphResize-spec.js
+++ b/src/test/unit/controls/Graph/GraphResize-spec.js
@@ -609,4 +609,27 @@ describe("Graph - Resize", () => {
             expect(graph.config.canvasHeight).toBe(250);
         });
     });
+    describe("Only when graph container is present", () => {
+        it("Resize the graph", (done) => {
+            expect(graph.config.canvasWidth).toBe(1024);
+            const canvasElement = fetchElementByClass(styles.canvas);
+            graphContainer.setAttribute("style", "width: 800px; height: 200px");
+            graph.resize();
+            triggerEvent(window, "resize", () => {
+                expect(graph.config.canvasWidth).toBe(800);
+                expect(graph.scale.x).not.toBeNull();
+                expect(graph.scale.x).toEqual(jasmine.any(Function));
+                expect(graph.scale.y).not.toBeNull();
+                expect(graph.scale.y).toEqual(jasmine.any(Function));
+                expect(toNumber(canvasElement.getAttribute("height"))).not.toBe(
+                    0
+                );
+                expect(
+                    toNumber(canvasElement.getAttribute("height"))
+                ).toBeGreaterThan(0);
+                expect(toNumber(canvasElement.getAttribute("width"))).toBe(790);
+                done();
+            });
+        });
+    });
 });


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

**What is the purpose of this pull request? (Check any that's applicable)**

-   [ ] Feature
-   [x] Bug fix
-   [ ] Dependency updates
-   [ ] Documentation updates
-   [ ] Build related changes
-   [ ] Changes an existing functionality
-   [ ] Other, please explain:

**Does this introduce a breaking change?**

-   [ ] Yes
-   [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

**What changes did you make? (Give an overview)**
Check if the graphContainer is present and then resize the graph.

**Add any screenshots**
Before
![image](https://user-images.githubusercontent.com/60426528/98666207-acf65200-2372-11eb-86eb-30a06ebef779.png)
After
No console errors in the browser.

